### PR TITLE
Set `monospace` as the default font

### DIFF
--- a/src/rabbit_boot_steps_visualiser_utils.erl
+++ b/src/rabbit_boot_steps_visualiser_utils.erl
@@ -19,6 +19,7 @@
 
 boot_steps_as_dot() ->
     Header = ["digraph BootSteps {"],
+    Attribs = ["node [fontname = monospace];"],
     Tail = ["}"],
     Steps = rabbit_boot_steps:find_steps(),
     Res =
@@ -30,7 +31,7 @@ boot_steps_as_dot() ->
                                         proplists:get_value(enables, Step)),
                   [Reqs, Ens | Acc]
           end, [], Steps),
-    [lists:concat(Header ++ Res ++ Tail)].
+    [lists:concat(Header ++ Attribs ++ Res ++ Tail)].
 
 process_enables(_StepName, undefined) ->
     [];


### PR DESCRIPTION
Courier is portable according to Graphviz's manual

Fixes #2
