### PR TITLE
Revert "Switch stable to Cowboy"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = rabbitmq_boot_steps_visualiser
 
-DEPS = rabbit_common rabbit rabbitmq_management
+DEPS = rabbit_common rabbit rabbitmq_management webmachine
 
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 

--- a/src/rabbit_boot_steps_visualiser_dispatch.erl
+++ b/src/rabbit_boot_steps_visualiser_dispatch.erl
@@ -19,6 +19,6 @@
 
 -export([dispatcher/0, web_ui/0]).
 
-dispatcher() -> [{"/boot_steps_visualiser", rabbit_boot_steps_visualiser_wm, []}].
+dispatcher() -> [{["boot_steps_visualiser"], rabbit_boot_steps_visualiser_wm, []}].
 
 web_ui()     -> [{javascript, <<"boot_steps_visualiser.js">>}].

--- a/src/rabbit_boot_steps_visualiser_wm.erl
+++ b/src/rabbit_boot_steps_visualiser_wm.erl
@@ -15,20 +15,18 @@
 
 -module(rabbit_boot_steps_visualiser_wm).
 
--export([init/3]).
--export([rest_init/2, to_json/2, content_types_provided/2, is_authorized/2]).
+-export([init/1, to_json/2, content_types_provided/2, is_authorized/2]).
 
 -import(rabbit_misc, [pget/2]).
 
 -include_lib("rabbitmq_management/include/rabbit_mgmt.hrl").
+-include_lib("webmachine/include/webmachine.hrl").
 
 %%--------------------------------------------------------------------
-init(_, _, _) -> {upgrade, protocol, cowboy_rest}.
-
-rest_init(ReqData, _) -> {ok, ReqData, #context{}}.
+init(_Config) -> {ok, #context{}}.
 
 content_types_provided(ReqData, Context) ->
-    {[{<<"application/json">>, to_json}], ReqData, Context}.
+    {[{"application/json", to_json}], ReqData, Context}.
 
 to_json(ReqData, Context) ->
     Steps = rabbit_boot_steps_visualiser_utils:boot_steps_as_dot(),


### PR DESCRIPTION
Reverts rabbitmq/rabbitmq-boot-steps-visualiser#9, which should go into `rabbitmq-management-236` instead.
